### PR TITLE
Reimplement and rename get_annotation function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ help: Makefile
 
 ## test:      run the automated test suite and print coverage information
 test:
-	pytest --cov=lusSTR lusSTR/tests/test_suite.py
+	pytest --cov=lusSTR --doctest-modules lusSTR/annot.py lusSTR/tests/test_suite.py
 
 ## style:     check code style against PEP8
 style:

--- a/lusSTR/annot.py
+++ b/lusSTR/annot.py
@@ -177,8 +177,8 @@ def get_blocks(sequence, n):
     '''
     Function to split a sequence into blocks of size n
 
-    This function is used as a part of the collapse_repeats_by_length() function. It splits the sequence
-    into blocks of size n bases (as specified in the str_markers.json file).
+    This function is used as a part of the collapse_repeats_by_length() function. It splits the
+    sequence into blocks of size n bases (as specified in the str_markers.json file).
     '''
     count = 0
     prev = None
@@ -714,8 +714,8 @@ def flank_3(full_seq, back, locus, n):
     elif locus == 'D18S51':
         flank = (
             f'{flank_seq[:2]} {collapse_repeats_by_length(flank_seq[2:30], 4)} {flank_seq[30:33]} '
-            f'{flank_seq[33]} {collapse_repeats_by_length(flank_seq[34:42], 4)} {flank_seq[42:44]} '
-            f'{flank_seq[44:]}'
+            f'{flank_seq[33]} {collapse_repeats_by_length(flank_seq[34:42], 4)} '
+            f'{flank_seq[42:44]} {flank_seq[44:]}'
         )
     elif locus == 'D16S539':
         flank = (

--- a/lusSTR/tests/test_suite.py
+++ b/lusSTR/tests/test_suite.py
@@ -92,9 +92,9 @@ def test_rev_comp_uas_output_bracket():
     assert rev_comp_bracket == 'CCAA [TTCG]2 [ACCT]3'
 
 
-def test_loci_need_split_anno():
+def test_collapse_repeats_by_length():
     sequence = 'TCTATCTATCTATCTATCTATCTATCTATATATCTATCTATCTATCTA'
-    assert lusSTR.annot.loci_need_split_anno(sequence, 4) == '[TCTA]7 TATA [TCTA]4'
+    assert lusSTR.annot.collapse_repeats_by_length(sequence, 4) == '[TCTA]7 TATA [TCTA]4'
 
 
 @pytest.mark.parametrize('sequence, bracket_form', [

--- a/lusSTR/tests/test_suite.py
+++ b/lusSTR/tests/test_suite.py
@@ -38,8 +38,8 @@ def test_format():
         'TAGATAGATAGATAGATGATAGATAGATAGATAGATAGATAGATAGATAGATAGATAGATAGATAGATAGATAGATAGATAGG'
     )
 ])
-def test_get_annotation(sequence, repeat_list, output):
-    final_output = lusSTR.annot.get_annotation(sequence, repeat_list)
+def test_collapse_all_repeats(sequence, repeat_list, output):
+    final_output = lusSTR.annot.collapse_all_repeats(sequence, repeat_list)
     assert final_output == output
 
 

--- a/lusSTR/tests/test_suite.py
+++ b/lusSTR/tests/test_suite.py
@@ -51,13 +51,13 @@ def test_split_by_n():
     ]
 
 
-def test_split_string():
+def test_sequence_to_bracketed_form():
     sequence = (
         'TCTATCTATCTATCTGTCTGTCTGTCTGTCTGTCTGTCTATCTATCTATATCTATCTATCTATCATCTATCTATCCATATCTATCTATC'
         'TATCTATCTATCTATCTATCTATCTATCTATCTA'
     )
     repeats = ['TCTA', 'TCTG']
-    final_output = lusSTR.annot.split_string(sequence, 6, repeats)
+    final_output = lusSTR.annot.sequence_to_bracketed_form(sequence, 6, repeats)
     assert final_output == '[TCTA]3 [TCTG]6 [TCTA]3 TA [TCTA]3 TCA [TCTA]2 TCCATA [TCTA]11'
 
 


### PR DESCRIPTION
This update replaces the `get_annotation` function with the new `collapse_tandem_repeat` and `collapse_all_repeats` functions.

I tried several ways to clean up the regex-based splitting approach, but this approach leads to unintuitive off-by-one errors for internal tandem repeats (i.e. 10 empty strings representing 11 copies of the repeat). Correcting for this resulted in opaque code any way I sliced it.

So I started from scratch and went with a recursive function that finds the first instance of the repeat in the sequence, collapses it, and then calls itself to repeat the process on the remaining sequence. This approach is a bit more concise and clear, and (most importantly) it works perfectly as a drop-in replacement for `get_annotation`!

I also added some doctests to the docstrings of the two new functions, so I updated `make test` in the Makefile to find and run these doctests. 