### PR TITLE
Refactor sequence and annotation reverse complementation

### DIFF
--- a/lusSTR/annot.py
+++ b/lusSTR/annot.py
@@ -18,6 +18,7 @@ import sys
 import lusSTR
 from lusSTR.repeat import collapse_all_repeats, collapse_repeats_by_length
 from lusSTR.repeat import sequence_to_bracketed_form, split_by_n
+from lusSTR.repeat import reverse_complement, reverse_complement_bracketed
 
 
 def get_str_metadata_file():
@@ -26,22 +27,6 @@ def get_str_metadata_file():
 
 with open(get_str_metadata_file(), 'r') as fh:
     str_dict = json.load(fh)
-
-
-def rev_complement_anno(sequence):
-    '''
-    Function creates reverse complement of sequence
-
-    Sequences in which the UAS software output contains the sequence on the reverse strand
-    require translation of the sequence to the forward strand. This allows for consistency
-    between both loci and any outside analyses in which comparisons may be made.
-    '''
-    complement = {'A': 'T', 'C': 'G', 'G': 'C', 'T': 'A'}
-    bases = list(sequence)
-    bases = [complement[base] for base in bases]
-    comp = ''.join(bases)
-    reverse_comp_sequence = comp[::-1]
-    return reverse_comp_sequence
 
 
 def rev_comp_forward_strand_bracket(
@@ -71,42 +56,6 @@ def rev_comp_forward_strand_bracket(
     else:
         forward_strand_brack_form = collapse_repeats_by_length(rev_sequence, n)
     return re.sub('  ', ' ', forward_strand_brack_form)
-
-
-def rev_comp_uas_output_bracket(forward_bracket, n):
-    '''
-    Function creates bracketed annotation for the UAS output sequence.
-
-    There may be instances where the bracketed annotation is required for the UAS output sequence.
-    This function performs the reverse complement of the forward strand bracketed annotation to
-    create the bracketed annotation for the UAS output (for those loci in which the UAS output
-    reports the reverse strand).
-    '''
-    ind = list(forward_bracket)
-    complement = {'A': 'T', 'C': 'G', 'G': 'C', 'T': 'A'}
-    reverse_strand_form = list()
-    for j in ind:
-        if j.isalpha():
-            reverse_strand_form.append(complement[j])
-        elif j == '[':
-            reverse_strand_form.append(']')
-        elif j == ']':
-            reverse_strand_form.append('[')
-        else:
-            reverse_strand_form.append(j)
-    reverse_form_anno_tmp = ''.join(reversed(reverse_strand_form))
-    reverse_form_anno_final = list()
-    for unit in reverse_form_anno_tmp.split(' '):
-        if '[' in unit:
-            if len(unit) == (n+3):
-                final_string = f'{unit[1:(len(unit))]}{unit[0]}'
-            else:
-                final_string = f'{unit[2:(len(unit))]}{unit[1]}{unit[0]}'
-            reverse_form_anno_final.append(final_string)
-        else:
-            reverse_form_anno_final.append(unit)
-    reverse_strand_bracketed_form = ' '.join(reverse_form_anno_final)
-    return re.sub('  ', ' ', reverse_strand_bracketed_form)
 
 
 def traditional_str_allele(sequence, n, n_sub_out):
@@ -537,7 +486,7 @@ def resolve_uas_sequence(sequence, str_data, kit, locus, n):
         uas_sequence = full_seq_to_uas(sequence, trim5, trim3)
     else:
         uas_from_full = full_seq_to_uas(sequence, trim5, trim3)
-        uas_sequence = rev_complement_anno(uas_from_full)
+        uas_sequence = reverse_complement(uas_from_full)
     return uas_sequence, flank_5_anno, flank_3_anno
 
 
@@ -680,12 +629,12 @@ def main(args):
         split_incompatible = len(uas_sequence) % no_of_repeat_bases != 0 and not havetosplit
         if cantsplit or split_incompatible:
             if str_dict[locus]['ReverseCompNeeded'] == 'Yes':
-                reverse_comp_sequence = rev_complement_anno(uas_sequence)
+                reverse_comp_sequence = reverse_complement(uas_sequence)
                 forward_strand_bracketed_form = rev_comp_forward_strand_bracket(
                     reverse_comp_sequence, no_of_repeat_bases, repeats, locus, cannot_split,
                     str_allele
                 )
-                reverse_strand_bracketed_form = rev_comp_uas_output_bracket(
+                reverse_strand_bracketed_form = reverse_complement_bracketed(
                     forward_strand_bracketed_form, no_of_repeat_bases
                 )
             elif locus == 'D21S11':
@@ -718,12 +667,12 @@ def main(args):
             elif locus == 'D13S317':
                 forward_strand_bracketed_form = D13_anno(uas_sequence, repeats)
             elif str_dict[locus]['ReverseCompNeeded'] == 'Yes':
-                reverse_comp_sequence = rev_complement_anno(uas_sequence)
+                reverse_comp_sequence = reverse_complement(uas_sequence)
                 forward_strand_bracketed_form = rev_comp_forward_strand_bracket(
                     reverse_comp_sequence, no_of_repeat_bases, repeats, locus, cannot_split,
                     str_allele
                 )
-                reverse_strand_bracketed_form = rev_comp_uas_output_bracket(
+                reverse_strand_bracketed_form = reverse_complement_bracketed(
                     forward_strand_bracketed_form, no_of_repeat_bases
                 )
             elif locus == 'PentaD':

--- a/lusSTR/annot.py
+++ b/lusSTR/annot.py
@@ -635,7 +635,7 @@ def main(args):
                     str_allele
                 )
                 reverse_strand_bracketed_form = reverse_complement_bracketed(
-                    forward_strand_bracketed_form, no_of_repeat_bases
+                    forward_strand_bracketed_form
                 )
             elif locus == 'D21S11':
                 forward_strand_bracketed_form = D21_bracket(
@@ -673,7 +673,7 @@ def main(args):
                     str_allele
                 )
                 reverse_strand_bracketed_form = reverse_complement_bracketed(
-                    forward_strand_bracketed_form, no_of_repeat_bases
+                    forward_strand_bracketed_form
                 )
             elif locus == 'PentaD':
                 forward_strand_bracketed_form = PentaD_annotation(

--- a/lusSTR/repeat.py
+++ b/lusSTR/repeat.py
@@ -100,3 +100,33 @@ def sequence_to_bracketed_form(sequence, n, repeats):
     result = ' '.join(blocks)
     result = re.sub(r' +', ' ', result)
     return result
+
+
+def reverse_complement(sequence):
+    '''
+    Function creates reverse complement of sequence
+
+    Sequences in which the UAS software output contains the sequence on the reverse strand
+    require translation of the sequence to the forward strand. This allows for consistency
+    between both loci and any outside analyses in which comparisons may be made.
+    '''
+    complement = {'A': 'T', 'C': 'G', 'G': 'C', 'T': 'A'}
+    rclist = [complement[base] for base in sequence[::-1]]
+    rc = ''.join(rclist)
+    return rc
+
+
+def reverse_complement_bracketed(forward_bracket, n):
+    '''Compute reverse complement of a bracketed form annotation.'''
+    inblocks = forward_bracket.split(' ')
+    outblocks = list()
+    for block in reversed(inblocks):
+        match = re.match(r'\[([ACGT]+)\](\d+)', block)
+        if match:
+            rcrep = reverse_complement(match.group(1))
+            count = match.group(2)
+            rcblock = f'[{rcrep}]{count}'
+        else:
+            rcblock = reverse_complement(block)
+        outblocks.append(rcblock)
+    return ' '.join(outblocks)

--- a/lusSTR/repeat.py
+++ b/lusSTR/repeat.py
@@ -116,7 +116,7 @@ def reverse_complement(sequence):
     return rc
 
 
-def reverse_complement_bracketed(forward_bracket, n):
+def reverse_complement_bracketed(forward_bracket):
     '''Compute reverse complement of a bracketed form annotation.'''
     inblocks = forward_bracket.split(' ')
     outblocks = list()

--- a/lusSTR/tests/test_repeat.py
+++ b/lusSTR/tests/test_repeat.py
@@ -63,5 +63,5 @@ def test_reverse_complement():
 
 def test_reverse_complement_bracketed():
     foward_strand = '[AGGT]3 [CGAA]2 TTGG'
-    rev_comp_bracket = reverse_complement_bracketed(foward_strand, 4)
+    rev_comp_bracket = reverse_complement_bracketed(foward_strand)
     assert rev_comp_bracket == 'CCAA [TTCG]2 [ACCT]3'

--- a/lusSTR/tests/test_repeat.py
+++ b/lusSTR/tests/test_repeat.py
@@ -9,7 +9,7 @@
 
 import lusSTR
 from lusSTR.repeat import collapse_tandem_repeat, collapse_all_repeats
-from lusSTR.repeat import split_by_n, get_blocks
+from lusSTR.repeat import split_by_n, get_blocks, reverse_complement, reverse_complement_bracketed
 from lusSTR.repeat import collapse_repeats_by_length, sequence_to_bracketed_form
 import pytest
 
@@ -51,3 +51,17 @@ def test_sequence_to_bracketed_form():
 def test_collapse_repeats_by_length():
     sequence = 'TCTATCTATCTATCTATCTATCTATCTATATATCTATCTATCTATCTA'
     assert collapse_repeats_by_length(sequence, 4) == '[TCTA]7 TATA [TCTA]4'
+
+
+def test_reverse_complement():
+    sequence = 'TAGATAGATAGATGATAGATAGATAGATAGATAGATAGATAGATAGATAGATAGATAGATAGGTGTGTGTGTGTG'
+    final_output = reverse_complement(sequence)
+    assert final_output == (
+        'CACACACACACACCTATCTATCTATCTATCTATCTATCTATCTATCTATCTATCTATCTATCATCTATCTATCTA'
+    )
+
+
+def test_reverse_complement_bracketed():
+    foward_strand = '[AGGT]3 [CGAA]2 TTGG'
+    rev_comp_bracket = reverse_complement_bracketed(foward_strand, 4)
+    assert rev_comp_bracket == 'CCAA [TTCG]2 [ACCT]3'

--- a/lusSTR/tests/test_suite.py
+++ b/lusSTR/tests/test_suite.py
@@ -12,6 +12,7 @@ import os
 import pandas as pd
 import pytest
 import lusSTR
+from lusSTR.repeat import reverse_complement
 from lusSTR.tests import data_file
 import re
 from tempfile import NamedTemporaryFile
@@ -36,26 +37,12 @@ def test_extract():
 
 def test_split_sequence_into_two_strings():
     sequence = 'TAGATAGATAGATGATAGATAGATAGATAGATAGATAGATAGATAGATAGATAGATAGATAGGTGTGTGTGTGTG'
-    reverse_comp_sequence = lusSTR.annot.rev_complement_anno(sequence)
+    reverse_comp_sequence = reverse_complement(sequence)
     repeat_for_split = 'CACA'
     seq1, seq2 = lusSTR.annot.split_sequence_into_two_strings(reverse_comp_sequence,
                                                               repeat_for_split)
     assert seq1 == 'CACACACACACA'
     assert seq2 == 'CCTATCTATCTATCTATCTATCTATCTATCTATCTATCTATCTATCTATCATCTATCTATCTA'
-
-
-def test_rev_complement_anno():
-    sequence = 'TAGATAGATAGATGATAGATAGATAGATAGATAGATAGATAGATAGATAGATAGATAGATAGGTGTGTGTGTGTG'
-    final_output = lusSTR.annot.rev_complement_anno(sequence)
-    assert final_output == (
-        'CACACACACACACCTATCTATCTATCTATCTATCTATCTATCTATCTATCTATCTATCTATCATCTATCTATCTA'
-    )
-
-
-def test_rev_comp_uas_output_bracket():
-    foward_strand = '[AGGT]3 [CGAA]2 TTGG'
-    rev_comp_bracket = lusSTR.annot.rev_comp_uas_output_bracket(foward_strand, 4)
-    assert rev_comp_bracket == 'CCAA [TTCG]2 [ACCT]3'
 
 
 @pytest.mark.parametrize('sequence, bracket_form', [
@@ -97,14 +84,14 @@ def test_D19_annotation():
     )
     repeats = ['TCTA', 'TCTG']
     repeat_for_split = 'CCTT'
-    reverse_comp_sequence = lusSTR.annot.rev_complement_anno(sequence)
+    reverse_comp_sequence = reverse_complement(sequence)
     final_output = lusSTR.annot.D19_annotation(reverse_comp_sequence, repeats, repeat_for_split)
     assert final_output == 'CT CTCT TTCT TCTT CTCT [CCTT]14 CCTA CCTT TT CCTT'
 
 
 def test_D1_annotation():
     sequence = 'TAGATAGATAGATAGATAGATAGATAGATAGATAGATAGATAGATGTGTATGTG'
-    reverse_comp_sequence = lusSTR.annot.rev_complement_anno(sequence)
+    reverse_comp_sequence = reverse_complement(sequence)
     repeats = ['TCTA', 'CATA', 'TCTG', 'CACA', 'CCTA']
     repeat_for_split = 'CACA'
     final_output = lusSTR.annot.D1_annotation(reverse_comp_sequence, repeats, repeat_for_split)
@@ -134,7 +121,7 @@ def test_FGA_anno():
         'TCTTTCTTTCTTTCTTTCTTTCTTTCTTTCTTTCTTTCTTTCTTCCTTCCTTCCTTTCTTTCTTTCTCCTTCCTTCCTTCCTTCC'
     )
     repeats = ['AAAG', 'GAAA', 'GAAG', 'ACAG', 'AAAA']
-    reverse_comp_sequence = lusSTR.annot.rev_complement_anno(sequence)
+    reverse_comp_sequence = reverse_complement(sequence)
     final_output = lusSTR.annot.FGA_anno(reverse_comp_sequence, repeats)
     assert final_output == '[GGAA]4 GGAG [AAAG]3 [GAAG]3 [AAAG]15 [ACAG]3 [AAAG]9 AA AAAA [GAAA]4'
 


### PR DESCRIPTION
This update renames the `rev_complement_anno` function to `reverse_complement`, and replaces the `rev_comp_uas_output_bracket` function with a new `reverse_complement_bracketed` function that is clearer and more concise. Both are drop-ins for the original functions: no other changes are required except to call the new function names.

Both functions were moved to the new `repeat` module. This is the logical home for the latter function, and for import reasons it was convenient to keep them together.