### PR TITLE
Refactor "format" module, add test

### DIFF
--- a/lusSTR/cli.py
+++ b/lusSTR/cli.py
@@ -16,7 +16,7 @@ def format_subparser(subparsers):
     cli = subparsers.add_parser('format')
     cli.add_argument(
         '-o', '--out', metavar='FILE',
-        help='file to which output will be written; default is terminal (stdout)'
+        help='File to which output will be written; default is terminal (stdout)'
     )
     cli.add_argument(
         'input',

--- a/lusSTR/format.py
+++ b/lusSTR/format.py
@@ -15,63 +15,54 @@ import re
 import sys
 
 
-def strait_razor_concat(input_dir):
-    '''
-    Function to prepare STRait Razor output for use in the 'annotate' lusSTR command.
+def uas_load(input_file):
+    '''Format a UAS Sample Details Report (.xlsx) for use with `lusSTR annotate`.'''
+    data = pd.read_excel(io=input_file, sheet_name=0)
+    offset = data[data.iloc[:, 0] == "Coverage Information"].index.tolist()[0]
+    results = data.iloc[offset + 2:]
+    results.columns = data.iloc[offset + 1]
+    results = results[results.Locus != 'Amelogenin'][['Locus', 'Reads', 'Repeat Sequence']]
+    results['SampleID'] = data.iloc[1, 1]
+    results['Project'] = data.iloc[2, 1]
+    results['Analysis'] = data.iloc[3, 1]
+    return results
 
-    STRait Razor outputs individual files per sample. The function formats each file
-    appropriately ('Locus', 'Total Reads', 'Sequence', 'SampleID') and then concatenates
-    all samples into one large file.
-    '''
-    loci_list = [
+
+def strait_razor_concat(input_dir):
+    '''Format a directory of STRait Razor output files for use with `lusSTR annotate`.'''
+    locus_list = [
         'CSF1PO', 'D10S1248', 'D12S391', 'D13S317', 'D16S539', 'D17S1301', 'D18S51', 'D19S433',
         'D1S1656', 'D20S482', 'D21S11', 'D22S1045', 'D2S1338', 'D2S441', 'D3S1358', 'D4S2408',
         'D5S818', 'D6S1043', 'D7S820', 'D8S1179', 'D9S1122', 'FGA', 'PentaD', 'PentaE', 'TH01',
         'TPOX', 'vWA'
-        ]
+    ]
     myfiles = os.listdir(input_dir)
-    straitrazorcomp = pd.DataFrame()
+    alldata = pd.DataFrame()
     for filename in sorted(myfiles):
-        name = re.sub("_STRaitRazor.txt", "", filename)
-        file = pd.read_table(input_dir + filename, sep="\t", header=None)
-        file.columns = ['Locus_allele', 'Length', 'Sequence', 'Forward_Reads', 'Reverse_Reads']
-        file[['Locus', 'Allele']] = file.Locus_allele.str.split(":", expand=True)
-        filtered_file = file[file['Locus'].isin(loci_list)]
-        filtered_file['Total_Reads'] = (
-            filtered_file['Forward_Reads'] + filtered_file['Reverse_Reads']
+        name = re.sub('_STRaitRazor.txt', '', filename)
+        filepath = os.path.join(input_dir, filename)
+        data = pd.read_csv(
+            filepath, sep='\t', header=None,
+            names=['Locus_allele', 'Length', 'Sequence', 'Forward_Reads', 'Reverse_Reads']
         )
-        filtered_file['SampleID'] = name
-        final_file = filtered_file.loc[:, ['Locus', 'Total_Reads', 'Sequence', 'SampleID']]
-        straitrazorcomp = straitrazorcomp.append(final_file)
-    straitrazorcomp.columns = ['Locus', 'Total_Reads', 'Sequence', 'SampleID']
-    return straitrazorcomp
+        data[['Locus', 'Allele']] = data.Locus_allele.str.split(":", expand=True)
+        data = data[data.Locus.isin(locus_list)]
+        data['Total_Reads'] = data['Forward_Reads'] + data['Reverse_Reads']
+        data['SampleID'] = name
+        data = data[['Locus', 'Total_Reads', 'Sequence', 'SampleID']]
+        alldata = alldata.append(data)
+    analysisID = input_dir.rstrip(os.sep)
+    analysisID_final = os.path.basename(analysisID)
+    alldata['Project'] = analysisID_final
+    alldata['Analysis'] = analysisID_final
+    return alldata
 
 
 def main(args):
-    '''
-    Script to convert either the UAS Sample Details Report (.xlsx format using the --uas flag)
-    or STRait Razor output to a more user-friendly format. Also removes the Amelogenin locus
-    and extract relevant information (e.g. Sample ID, Project ID and Analysis ID).
-    '''
     if args.uas:
-        file = pd.read_excel(io=args.input, sheet_name=0)
-        well_index = file[
-            file["Sample Autosomal STR Report"] == "Coverage Information"].index.tolist()
-        results_newdf = file[(well_index[0] + 2):]
-        results_newdf.columns = file.iloc[(well_index[0] + 1)]
-        results_filt = results_newdf[results_newdf.Locus != "Amelogenin"]
-        results_final = results_filt[['Locus', 'Reads', 'Repeat Sequence']]
-        results_final['SampleID'] = file.iloc[1, 1]
-        results_final['Project'] = file.iloc[2, 1]
-        results_final['Analysis'] = file.iloc[3, 1]
+        results = uas_load(args.input)
     else:
-        results_final = strait_razor_concat(args.input)
-        path = args.input
-        analysisID = path.rstrip(os.sep)
-        analysisID_final = os.path.basename(analysisID)
-        results_final['Project'] = analysisID_final
-        results_final['Analysis'] = analysisID_final
-
-    output_file = sys.stdout
-    if args.out is not None:
-        results_final.to_csv(args.out, index=False)
+        results = strait_razor_concat(args.input)
+    if args.out is None:
+        args.out = sys.stdout
+    results.to_csv(args.out, index=False)

--- a/lusSTR/tests/test_format.py
+++ b/lusSTR/tests/test_format.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+#
+# -----------------------------------------------------------------------------
+# Copyright (c) 2020, Battelle National Biodefense Institute.
+#
+# This file is part of lusSTR (http://github.com/bioforensics/lusSTR)
+# and is licensed under the BSD license: see LICENSE.txt.
+# -----------------------------------------------------------------------------
+
+import filecmp
+import lusSTR
+from lusSTR.tests import data_file
+from tempfile import NamedTemporaryFile
+
+
+def test_format():
+    UAStestfile = data_file('UAS_Sample_Details_Report_test.xlsx')
+    formatoutput = data_file('testformat.csv')
+    with NamedTemporaryFile(suffix='.csv') as outfile:
+        arglist = ['format', UAStestfile, '-o', outfile.name, '--uas']
+        args = lusSTR.cli.get_parser().parse_args(arglist)
+        lusSTR.format.main(args)
+        assert filecmp.cmp(formatoutput, outfile.name) is True
+
+
+def test_format_stdout(capsys):
+    UAStestfile = data_file('UAS_Sample_Details_Report_test.xlsx')
+    formatoutput = data_file('testformat.csv')
+    arglist = ['format', UAStestfile, '--uas']
+    args = lusSTR.cli.get_parser().parse_args(arglist)
+    lusSTR.format.main(args)
+    with open(formatoutput, 'r') as fh:
+        exp_out = fh.read().strip()
+    terminal = capsys.readouterr()
+    obs_out = terminal.out.strip()
+    assert obs_out == exp_out
+
+
+def test_format_straitrazor():
+    with NamedTemporaryFile() as outfile:
+        inputdb = data_file('STRait_Razor_test_output/')
+        testformat = data_file('STRait_Razor_test_output.csv')
+        arglist = ['format', inputdb, '-o', outfile.name]
+        args = lusSTR.cli.get_parser().parse_args(arglist)
+        lusSTR.format.main(args)
+        assert filecmp.cmp(testformat, outfile.name) is True

--- a/lusSTR/tests/test_suite.py
+++ b/lusSTR/tests/test_suite.py
@@ -19,16 +19,6 @@ import re
 from tempfile import NamedTemporaryFile
 
 
-def test_format():
-    UAStestfile = data_file('UAS_Sample_Details_Report_test.xlsx')
-    formatoutput = data_file('testformat.csv')
-    with NamedTemporaryFile(suffix='.csv') as outfile:
-        arglist = ['format', UAStestfile, '-o', outfile.name, '--uas']
-        args = lusSTR.cli.get_parser().parse_args(arglist)
-        lusSTR.format.main(args)
-        assert filecmp.cmp(formatoutput, outfile.name) is True
-
-
 def test_split_sequence_into_two_strings():
     sequence = 'TAGATAGATAGATGATAGATAGATAGATAGATAGATAGATAGATAGATAGATAGATAGATAGGTGTGTGTGTGTG'
     reverse_comp_sequence = reverse_complement(sequence)
@@ -62,16 +52,6 @@ def test_annotate_full_nocombine():
         outfile_name = os.path.splitext(outfile.name)[0]
         outfile_name_output = f'{outfile_name}_no_combined_reads.txt'
         assert filecmp.cmp(testfullanno, outfile_name_output) is True
-
-
-def test_format_straitrazor():
-    with NamedTemporaryFile() as outfile:
-        inputdb = data_file('STRait_Razor_test_output/')
-        testformat = data_file('STRait_Razor_test_output.csv')
-        arglist = ['format', inputdb, '-o', outfile.name]
-        args = lusSTR.cli.get_parser().parse_args(arglist)
-        lusSTR.format.main(args)
-        assert filecmp.cmp(testformat, outfile.name) is True
 
 
 def test_flank_anno():


### PR DESCRIPTION
Running the test suite at the moment results in several `SettingWithCopyWarning` messages. This update began as an attempt to clean up these messages, but I ended up reorganizing the "format" module code a bit and making a few changes for clarity. I also added a test to make sure that the advertised "print to stdout" functionality works correctly.